### PR TITLE
Fix: Ensure correct image transform in SVG export

### DIFF
--- a/src/drawControllers/svg.drawController.ts
+++ b/src/drawControllers/svg.drawController.ts
@@ -237,13 +237,26 @@ export class SvgDrawController implements DrawController {
 		ctx.drawImage(imageElement, 0, 0);
 		const dataUri = canvas.toDataURL(); // Convert the image to Base64
 
-		const transform = angle
-			? `transform="rotate(${angle}, ${xMin + width / 2}, ${yMin + height / 2})"`
-			: '';
+		const svgWidth = width * this.getScreenScale();
+		const svgHeight = height * this.getScreenScale();
+
+		const worldCenterX = xMin + width / 2;
+		const worldCenterY = yMin + height / 2;
+
+		const targetCenter = this.worldToTarget(new Point(worldCenterX, worldCenterY));
+
+		const svgX = targetCenter.x - svgWidth / 2;
+		const svgY = targetCenter.y - svgHeight / 2;
+
+		let transformAttribute = '';
+		if (angle !== 0) {
+			const svgAngleDegrees = angle * (180 / Math.PI);
+			transformAttribute = `transform="rotate(${svgAngleDegrees}, ${targetCenter.x}, ${targetCenter.y})"`;
+		}
 
 		// noinspection HtmlUnknownAttribute
 		this.svgStrings.push(
-			`<image href="${dataUri}" x="${xMin}" y="${yMin}" width="${width}" height="${height}" ${transform} />`
+			`<image href="${dataUri}" x="${svgX}" y="${svgY}" width="${svgWidth}" height="${svgHeight}" ${transformAttribute} />`
 		);
 	}
 


### PR DESCRIPTION
Modified SvgDrawController.drawImage to correctly convert image coordinates, dimensions, and rotation from world space to SVG screen space. This involves:
- Scaling dimensions by the screen scale.
- Transforming the image center to target SVG coordinates.
- Calculating SVG x, y for the <image> tag based on the transformed center.
- Applying rotation in degrees around the transformed center.

This change addresses issue #18 where images were not appearing correctly in exported SVG files due to improper coordinate handling.